### PR TITLE
[Feat] 홈뷰 로그인 로직 삭제

### DIFF
--- a/Amor.xcodeproj/project.pbxproj
+++ b/Amor.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		043D4D802CD75EF100AA580B /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D7F2CD75EF100AA580B /* LoginResponseDTO.swift */; };
 		043D4D822CD75F9200AA580B /* DMRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D812CD75F9200AA580B /* DMRepository.swift */; };
 		043D4D842CD75FAE00AA580B /* DefaultDMRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D832CD75FAE00AA580B /* DefaultDMRepository.swift */; };
-		043D4D862CD760FE00AA580B /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D852CD760FE00AA580B /* LoginModel.swift */; };
+		043D4D862CD760FE00AA580B /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D852CD760FE00AA580B /* Login.swift */; };
 		043D4D882CD7743D00AA580B /* DMTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D872CD7743D00AA580B /* DMTarget.swift */; };
 		043D4D942CD77B9C00AA580B /* SpaceMembersRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D932CD77B9C00AA580B /* SpaceMembersRequestDTO.swift */; };
 		043D4D962CD77BE700AA580B /* SpaceMemberResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D4D952CD77BE700AA580B /* SpaceMemberResponseDTO.swift */; };
@@ -195,7 +195,7 @@
 		043D4D7F2CD75EF100AA580B /* LoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDTO.swift; sourceTree = "<group>"; };
 		043D4D812CD75F9200AA580B /* DMRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMRepository.swift; sourceTree = "<group>"; };
 		043D4D832CD75FAE00AA580B /* DefaultDMRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDMRepository.swift; sourceTree = "<group>"; };
-		043D4D852CD760FE00AA580B /* LoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModel.swift; sourceTree = "<group>"; };
+		043D4D852CD760FE00AA580B /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
 		043D4D872CD7743D00AA580B /* DMTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMTarget.swift; sourceTree = "<group>"; };
 		043D4D932CD77B9C00AA580B /* SpaceMembersRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceMembersRequestDTO.swift; sourceTree = "<group>"; };
 		043D4D952CD77BE700AA580B /* SpaceMemberResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceMemberResponseDTO.swift; sourceTree = "<group>"; };
@@ -587,7 +587,7 @@
 			children = (
 				043D4DCA2CD8E65500AA580B /* MyProfile.swift */,
 				049F12BF2CDD0AEC00305F55 /* ProfileElement.swift */,
-				043D4D852CD760FE00AA580B /* LoginModel.swift */,
+				043D4D852CD760FE00AA580B /* Login.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -1218,7 +1218,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				043D4D862CD760FE00AA580B /* LoginModel.swift in Sources */,
+				043D4D862CD760FE00AA580B /* Login.swift in Sources */,
 				881E04742CF9AA590078B03F /* Notification+.swift in Sources */,
 				04C1D7AB2CE77DB90012A8DD /* ChannelRequestDTO.swift in Sources */,
 				043D4D982CD77FB900AA580B /* SpaceMember.swift in Sources */,

--- a/Amor/Common/Constant/Design.swift
+++ b/Amor/Common/Constant/Design.swift
@@ -33,4 +33,8 @@ enum Design {
         static let xmark = UIImage(named: "Xmark")!
         static let threeDots = UIImage(named: "ThreeDots")!
     }
+    
+    enum Empty {
+        static let image = UIImage(named: "onboarding")
+    }
 }

--- a/Amor/Data/DTO/User/LoginResponseDTO.swift
+++ b/Amor/Data/DTO/User/LoginResponseDTO.swift
@@ -20,13 +20,13 @@ struct TokenResponseDTO: Decodable {
 }
 
 extension LoginResponseDTO {
-    func toDomain() -> LoginModel {
-        LoginModel(self)
+    func toDomain() -> Login {
+        Login(self)
     }
 }
 
 extension TokenResponseDTO {
-    func toDomain() -> TokenModel {
-        TokenModel(self)
+    func toDomain() -> Token {
+        Token(self)
     }
 }

--- a/Amor/Domain/Entity/User/Login.swift
+++ b/Amor/Domain/Entity/User/Login.swift
@@ -27,11 +27,11 @@ extension LoginRequestModel {
 /* Domain: 로그인 응답 모델 
  * DTO -> Response
  */
-struct LoginModel {
+struct Login {
     let user_id: String
     let nickname: String
     let profileImage: String?
-    let token: TokenModel
+    let token: Token
     
     init(_ dto: LoginResponseDTO) {
         self.user_id = dto.user_id
@@ -41,7 +41,7 @@ struct LoginModel {
     }
 }
 
-struct TokenModel {
+struct Token {
     let accessToken: String
     let refreshToken: String
     

--- a/Amor/Domain/UseCase/DMUseCase.swift
+++ b/Amor/Domain/UseCase/DMUseCase.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 protocol DMUseCase {
     func login(request: LoginRequestDTO) 
-    -> Single<Result<LoginModel, NetworkError>>
+    -> Single<Result<Login, NetworkError>>
     func getSpaceMembers(request: SpaceMembersRequestDTO)
     -> Single<Result<[SpaceMember], NetworkError>>
     func getDMRooms(request: DMRoomRequestDTO) 
@@ -28,7 +28,7 @@ final class DefaultDMUseCase: DMUseCase {
         self.spaceRepository = spaceRepository
     }
     
-    func login(request: LoginRequestDTO) -> Single<Result<LoginModel, NetworkError>> {
+    func login(request: LoginRequestDTO) -> Single<Result<Login, NetworkError>> {
         userRepository.login(requestDTO: request)
             .flatMap{ result in
                 switch result {

--- a/Amor/Domain/UseCase/UserUseCase.swift
+++ b/Amor/Domain/UseCase/UserUseCase.swift
@@ -10,9 +10,12 @@ import RxSwift
 import Kingfisher
 
 protocol UserUseCase {
-    func validateEmail(_ email: String) -> Observable<Bool>
-    func validatePassword(_ password: String) -> Observable<Bool>
-    func login(request: LoginRequestModel) -> Single<Result<LoginModel, NetworkError>>
+    func validateEmail(_ email: String)
+    -> Observable<Bool>
+    func validatePassword(_ password: String)
+    -> Observable<Bool>
+    func login(request: LoginRequestModel)
+    -> Single<Result<Login, NetworkError>>
     func getMyProfile()
     -> Single<Result<MyProfile, NetworkError>>
 }
@@ -35,7 +38,7 @@ final class DefaultUserUseCase: UserUseCase {
     }
     
     func login(request: LoginRequestModel) 
-    -> Single<Result<LoginModel, NetworkError>> {
+    -> Single<Result<Login, NetworkError>> {
         repository.login(requestDTO: request.toDTO())
             .flatMap { result in
                 switch result {

--- a/Amor/Presentation/Coordinator/AppCoordinator.swift
+++ b/Amor/Presentation/Coordinator/AppCoordinator.swift
@@ -34,7 +34,7 @@ final class AppCoordinator: Coordinator {
         let tabCoordinator = TabCoordinator(navigationController: navigationController)
         tabCoordinator.parentCoordinator = self
         childCoordinators.append(tabCoordinator)
-        tabCoordinator.tabBarHidden()
+        tabCoordinator.navigationBarHidden()
         tabCoordinator.start()
     }
 }

--- a/Amor/Presentation/Coordinator/HomeCoordinator.swift
+++ b/Amor/Presentation/Coordinator/HomeCoordinator.swift
@@ -85,4 +85,12 @@ final class HomeCoordinator: Coordinator {
             }
         }
     }
+    
+    func showLoginFlow() {
+        if let tabCoordinator = parentCoordinator as? TabCoordinator, let appCoordinator = tabCoordinator.parentCoordinator as? AppCoordinator {
+            // 메인 플로우(TabCoordinator) 제거
+            appCoordinator.childCoordinators.removeAll(where: { $0 is TabCoordinator })
+            appCoordinator.showUserFlow()
+        }
+    }
 }

--- a/Amor/Presentation/Coordinator/TabCoordinator.swift
+++ b/Amor/Presentation/Coordinator/TabCoordinator.swift
@@ -49,7 +49,7 @@ final class TabCoordinator: Coordinator {
         navigationController.viewControllers = [tabBarController]
     }
     
-    func tabBarHidden() {
+    func navigationBarHidden() {
         self.navigationController.isNavigationBarHidden = true
     }
 }

--- a/Amor/Presentation/CustomView/SpaceNavigationBarView.swift
+++ b/Amor/Presentation/CustomView/SpaceNavigationBarView.swift
@@ -62,7 +62,7 @@ final class SpaceNavigationBarView: UIView {
         if let imageURL = image, let url = URL(string: apiUrl + imageURL) {
             spaceImageView.kf.setImage(with: url)
         } else {
-            spaceImageView.image = UIImage(systemName: "star")
+            spaceImageView.backgroundColor = .themeBlack
         }
     }
     

--- a/Amor/Presentation/Home/View/HomeView.swift
+++ b/Amor/Presentation/Home/View/HomeView.swift
@@ -113,5 +113,9 @@ final class HomeView: BaseView {
         emptySubtitleLabel.isHidden = !show
         emptyImageView.isHidden = !show
         createSpaceButton.isHidden = !show
+        
+        emptyImageView.image = show ? .onboarding : nil
+        navBar.configureSpaceImageView(image: nil)
+        navBar.configureMyProfileImageView(image: nil)
     }
 }

--- a/Amor/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Amor/Presentation/Home/ViewController/HomeViewController.swift
@@ -42,16 +42,14 @@ final class HomeViewController: BaseVC<HomeView> {
         output.myProfileImage
             .bind(with: self) { owner, value in
                 owner.baseView.navBar.configureMyProfileImageView(image: value)
+                owner.baseView.showEmptyView(show: false)
             }
             .disposed(by: disposeBag)
         
         output.noSpace
             .bind(with: self) { owner, value in
-                print(value)
-                if value {
-                    owner.baseView.navBar.configureNavTitle(.home("No Space"))
-                }
-                owner.baseView.showEmptyView(show: value)
+                owner.baseView.navBar.configureNavTitle(.home("No Space"))
+                owner.baseView.showEmptyView(show: true)
             }
             .disposed(by: disposeBag)
         
@@ -149,6 +147,12 @@ final class HomeViewController: BaseVC<HomeView> {
                 }
                 .disposed(by: disposeBag)
         }
+        
+        output.backLoginView
+            .bind(with: self) { owner, _ in
+                owner.coordinator?.showLoginFlow()
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Amor/Presentation/User/ViewModel/MyProfileViewModel.swift
+++ b/Amor/Presentation/User/ViewModel/MyProfileViewModel.swift
@@ -48,7 +48,7 @@ final class MyProfileViewModel: BaseViewModel {
                         case .email:
                             result.append(ProfileElement(profileElement: .email, value: profile.email))
                         case .provider:
-                            if let provider = profile.provider {
+                            if let _ = profile.provider {
                                 result.append(ProfileElement(profileElement: .provider, value: profile.provider))
                             } else {
                                 break


### PR DESCRIPTION
## 🚀관련 이슈
- #36 

## ✨작업 내용
- LoginModel 네이밍 변경(Login)
- Design에 Empty뷰 표시를 위한 onBoarding 이미지 코드 추가
- 홈뷰의 Empty뷰 표시 로직 코드 수정
- Home뷰 트리거 시 로그인 로직 코드 삭제 & 내 프로필 불러오기 먼저 시도
- 내 프로필 불러오기에 실패한 경우 로그인 화면으로 이동
- HomeCoordinator에 로그인화면 이동 로직 코드 추가

