### PR TITLE
[Feat] 스페이스 관리자 변경 기능 구현

### DIFF
--- a/Amor.xcodeproj/project.pbxproj
+++ b/Amor.xcodeproj/project.pbxproj
@@ -43,9 +43,12 @@
 		0450D1A12D0036D5007B36F4 /* AlertText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A02D0036D5007B36F4 /* AlertText.swift */; };
 		0450D1A32D004DCE007B36F4 /* ChangeSpaceOwnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A22D004DCE007B36F4 /* ChangeSpaceOwnerView.swift */; };
 		0450D1A52D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A42D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift */; };
+		0450D1A72D0069A0007B36F4 /* ChangeSpaceOwnerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A62D0069A0007B36F4 /* ChangeSpaceOwnerViewModel.swift */; };
+		0450D1A92D006E05007B36F4 /* ChangeSpaceOwnerRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A82D006E05007B36F4 /* ChangeSpaceOwnerRequestDTO.swift */; };
 		046688D62CE9F84100CA9E53 /* SpaceInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046688D52CE9F84100CA9E53 /* SpaceInfoResponseDTO.swift */; };
 		046688D92CE9F89D00CA9E53 /* SpaceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046688D82CE9F89D00CA9E53 /* SpaceInfo.swift */; };
 		046688DC2CEA43B600CA9E53 /* SpaceRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046688DB2CEA43B600CA9E53 /* SpaceRequestDTO.swift */; };
+		0490C67B2D0080B00073E3BD /* ActionSheetText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0490C67A2D0080B00073E3BD /* ActionSheetText.swift */; };
 		049309562CCE1FEB0059271A /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049309552CCE1FEB0059271A /* BaseView.swift */; };
 		049309582CCE1FF10059271A /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049309572CCE1FF10059271A /* BaseVC.swift */; };
 		0493095A2CCE21760059271A /* DMView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049309592CCE21760059271A /* DMView.swift */; };
@@ -240,9 +243,12 @@
 		0450D1A02D0036D5007B36F4 /* AlertText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertText.swift; sourceTree = "<group>"; };
 		0450D1A22D004DCE007B36F4 /* ChangeSpaceOwnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSpaceOwnerView.swift; sourceTree = "<group>"; };
 		0450D1A42D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSpaceOwnerViewController.swift; sourceTree = "<group>"; };
+		0450D1A62D0069A0007B36F4 /* ChangeSpaceOwnerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSpaceOwnerViewModel.swift; sourceTree = "<group>"; };
+		0450D1A82D006E05007B36F4 /* ChangeSpaceOwnerRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSpaceOwnerRequestDTO.swift; sourceTree = "<group>"; };
 		046688D52CE9F84100CA9E53 /* SpaceInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceInfoResponseDTO.swift; sourceTree = "<group>"; };
 		046688D82CE9F89D00CA9E53 /* SpaceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceInfo.swift; sourceTree = "<group>"; };
 		046688DB2CEA43B600CA9E53 /* SpaceRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceRequestDTO.swift; sourceTree = "<group>"; };
+		0490C67A2D0080B00073E3BD /* ActionSheetText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetText.swift; sourceTree = "<group>"; };
 		049309552CCE1FEB0059271A /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		049309572CCE1FF10059271A /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		049309592CCE21760059271A /* DMView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMView.swift; sourceTree = "<group>"; };
@@ -650,6 +656,7 @@
 			children = (
 				04E98C1A2CF97CA600B60F10 /* SideSpaceMenuViewModel.swift */,
 				0450810D2CFAD6F7009423C9 /* SpaceActiveViewModel.swift */,
+				0450D1A62D0069A0007B36F4 /* ChangeSpaceOwnerViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -674,6 +681,7 @@
 				043D4D952CD77BE700AA580B /* SpaceMemberResponseDTO.swift */,
 				04E98C212CF9ADE800B60F10 /* SpaceSimpleInfoResponseDTO.swift */,
 				04E98C1F2CF9ADC300B60F10 /* SpaceSimpleInfo.swift */,
+				0450D1A82D006E05007B36F4 /* ChangeSpaceOwnerRequestDTO.swift */,
 			);
 			path = Space;
 			sourceTree = "<group>";
@@ -831,6 +839,7 @@
 				04B8C5DB2CF31A3F0069FD00 /* Design.swift */,
 				885B544B2CF89A3D00128322 /* ToastText.swift */,
 				0450D1A02D0036D5007B36F4 /* AlertText.swift */,
+				0490C67A2D0080B00073E3BD /* ActionSheetText.swift */,
 				8838CE3F2CFAD20C001C1189 /* Navigation.swift */,
 				049AB4652CFC4D1B00A78D73 /* HomeAddText.swift */,
 			);
@@ -1417,6 +1426,7 @@
 				044740192CF0A12400E8A451 /* DMCoordinator.swift in Sources */,
 				04E8299B2CE8864D007D14F9 /* HomeSectionModel.swift in Sources */,
 				88FA05682CD603E50084A3B0 /* TokenManager.swift in Sources */,
+				0450D1A92D006E05007B36F4 /* ChangeSpaceOwnerRequestDTO.swift in Sources */,
 				04BECF3B2CFEDF480030D5A7 /* AddMemberView.swift in Sources */,
 				04E98C172CF97C5E00B60F10 /* SideSpaceMenuView.swift in Sources */,
 				049309562CCE1FEB0059271A /* BaseView.swift in Sources */,
@@ -1427,8 +1437,10 @@
 				0433C82E2CD49CFF00869D63 /* UIView+.swift in Sources */,
 				881E04762CF9BC010078B03F /* ChatRequestBodyDTO.swift in Sources */,
 				049F12C22CDD0EF400305F55 /* ProfileSectionModel.swift in Sources */,
+				0490C67B2D0080B00073E3BD /* ActionSheetText.swift in Sources */,
 				04BECF412CFEEDC00030D5A7 /* AddMemberRequestDTO.swift in Sources */,
 				04FE94712CF724CD005C0337 /* AddChannelDelegate.swift in Sources */,
+				0450D1A72D0069A0007B36F4 /* ChangeSpaceOwnerViewModel.swift in Sources */,
 				887892C72CD50D2300F3C732 /* UserTarget.swift in Sources */,
 				8846415C2CF1B59E009D4FFB /* ChatViewController.swift in Sources */,
 				EFD78DDF2CCE8F6A00CE7A57 /* LabeledTextField.swift in Sources */,

--- a/Amor.xcodeproj/project.pbxproj
+++ b/Amor.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		045081102CFAE8A1009423C9 /* EditSpaceRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450810F2CFAE8A1009423C9 /* EditSpaceRequestDTO.swift */; };
 		0450D19F2D0023DC007B36F4 /* SideSpaceMenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D19E2D0023DC007B36F4 /* SideSpaceMenuCoordinator.swift */; };
 		0450D1A12D0036D5007B36F4 /* AlertText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A02D0036D5007B36F4 /* AlertText.swift */; };
+		0450D1A32D004DCE007B36F4 /* ChangeSpaceOwnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A22D004DCE007B36F4 /* ChangeSpaceOwnerView.swift */; };
+		0450D1A52D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0450D1A42D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift */; };
 		046688D62CE9F84100CA9E53 /* SpaceInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046688D52CE9F84100CA9E53 /* SpaceInfoResponseDTO.swift */; };
 		046688D92CE9F89D00CA9E53 /* SpaceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046688D82CE9F89D00CA9E53 /* SpaceInfo.swift */; };
 		046688DC2CEA43B600CA9E53 /* SpaceRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046688DB2CEA43B600CA9E53 /* SpaceRequestDTO.swift */; };
@@ -236,6 +238,8 @@
 		0450810F2CFAE8A1009423C9 /* EditSpaceRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSpaceRequestDTO.swift; sourceTree = "<group>"; };
 		0450D19E2D0023DC007B36F4 /* SideSpaceMenuCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideSpaceMenuCoordinator.swift; sourceTree = "<group>"; };
 		0450D1A02D0036D5007B36F4 /* AlertText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertText.swift; sourceTree = "<group>"; };
+		0450D1A22D004DCE007B36F4 /* ChangeSpaceOwnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSpaceOwnerView.swift; sourceTree = "<group>"; };
+		0450D1A42D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSpaceOwnerViewController.swift; sourceTree = "<group>"; };
 		046688D52CE9F84100CA9E53 /* SpaceInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceInfoResponseDTO.swift; sourceTree = "<group>"; };
 		046688D82CE9F89D00CA9E53 /* SpaceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceInfo.swift; sourceTree = "<group>"; };
 		046688DB2CEA43B600CA9E53 /* SpaceRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceRequestDTO.swift; sourceTree = "<group>"; };
@@ -636,6 +640,7 @@
 				04E98C162CF97C5E00B60F10 /* SideSpaceMenuView.swift */,
 				88A9D17B2CD26A14003F4A22 /* SpaceActiveView.swift */,
 				8890133E2CD1130900B5FF91 /* SpaceInitialView.swift */,
+				0450D1A22D004DCE007B36F4 /* ChangeSpaceOwnerView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -760,6 +765,7 @@
 				04E98C182CF97C8200B60F10 /* SideSpaceMenuViewController.swift */,
 				8890133C2CD1125000B5FF91 /* SpaceInitialViewController.swift */,
 				88A9D17D2CD26A30003F4A22 /* SpaceActiveViewController.swift */,
+				0450D1A42D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1277,6 +1283,7 @@
 				8890CD9F2CF37B1000528C2A /* ChannelMemberDTO.swift in Sources */,
 				EFD78DD92CCE895800CE7A57 /* DividerView.swift in Sources */,
 				884DD4342CE474260004CC13 /* LoginView.swift in Sources */,
+				0450D1A52D004DE3007B36F4 /* ChangeSpaceOwnerViewController.swift in Sources */,
 				884DD4302CE46BDF0004CC13 /* UserUseCase.swift in Sources */,
 				043D4DBA2CD8C2E500AA580B /* EditProfileViewController.swift in Sources */,
 				04B8C5EB2CF48DB50069FD00 /* ChatCoordinator.swift in Sources */,
@@ -1301,6 +1308,7 @@
 				8838CE402CFAD20C001C1189 /* Navigation.swift in Sources */,
 				0447401D2CF0A17600E8A451 /* SettingCoordinator.swift in Sources */,
 				889A1C942CF44DB7005B6EA6 /* DateFormatManager.swift in Sources */,
+				0450D1A32D004DCE007B36F4 /* ChangeSpaceOwnerView.swift in Sources */,
 				0447407B2CF1A64C00E8A451 /* DIContainer.swift in Sources */,
 				049309602CCE2FC90059271A /* BaseCollectionViewCell.swift in Sources */,
 				04E829B42CE9D10B007D14F9 /* SpaceRepository.swift in Sources */,

--- a/Amor/Common/Constant/ActionSheetText.swift
+++ b/Amor/Common/Constant/ActionSheetText.swift
@@ -1,0 +1,35 @@
+//
+//  ActionSheetText.swift
+//  Amor
+//
+//  Created by 김상규 on 12/4/24.
+//
+
+import Foundation
+
+enum ActionSheetText {
+    enum SpaceActionSheetText: String {
+        case leave = "스페이스 나가기"
+        case edit = "스페이스 편집"
+        case changeOwner = "스페이스 관리자 변경"
+        case delete = "스페이스 삭제"
+        case cancel = "취소"
+        
+        var alertDescription: String {
+            switch self {
+            case .leave:
+                return "회원님은 워크스페이스 관리자입니다. 스페이스 관리자를 다른 멤버로 변경한 후 나갈 수 있습니다."
+            case .delete:
+                return "정말 이 스페이스를 삭제하시겠습니까? 삭제 시 채널/멤버/채팅 등 스페이스 내의 모든 정보가 삭제되며 복구할 수 없습니다."
+            case .edit, .changeOwner, .cancel:
+                return ""
+            }
+        }
+    }
+    
+    enum ChannelActionSheetText: String {
+        case add = "채널 추가"
+        case search = "채널 탐색"
+        case cancel = "취소"
+    }
+}

--- a/Amor/Common/Constant/AlertText.swift
+++ b/Amor/Common/Constant/AlertText.swift
@@ -14,7 +14,32 @@ enum AlertText {
     }
     
     enum ChangeSpaceOwnerAlertText {
-        static let title = "워크스페이스 관리자 변경 불가"
-        static let description = "워크스페이스 멤버가 없어 관리자 변경을 할 수 없습니다. 새로운 멤버를 워크스페이스에 초대해보세요."
+        case changeDisabled
+        case changeEnalbled(String)
+        
+        var title: String {
+            switch self {
+            case .changeDisabled:
+                return "워크스페이스 관리자 변경 불가"
+            case .changeEnalbled(let member):
+                return "\(member)님을 관리자로 변경하시겠습니까?"
+            }
+        }
+        
+        var description: String {
+            switch self {
+            case .changeDisabled:
+                return "워크스페이스 멤버가 없어 관리자 변경을 할 수 없습니다. 새로운 멤버를 워크스페이스에 초대해보세요."
+            case .changeEnalbled:
+                return
+"""
+워크스페이스 관리자는 다음과 같은 권한이 있습니다.
+
+﹒워크스페이스 이름 또는 설명 변경
+﹒워크스페이스 삭제
+﹒워크스페이스 멤버 초대
+"""
+            }
+        }
     }
 }

--- a/Amor/Common/Constant/AlertText.swift
+++ b/Amor/Common/Constant/AlertText.swift
@@ -7,37 +7,14 @@
 
 import Foundation
 
-enum AlertButtonText: String {
-    case confirm = "확인"
-    case cancel = "취소"
-}
-
-enum ActionSheetType {
-    case channel(SpaceActionSheetText)
-    case space(ChannelActionSheetText)
-}
-
-enum SpaceActionSheetText: String {
-    case leave = "스페이스 나가기"
-    case edit = "스페이스 편집"
-    case changeOwner = "스페이스 관리자 변경"
-    case delete = "스페이스 삭제"
-    case cancel = "취소"
-    
-    var alertDescription: String {
-        switch self {
-        case .leave:
-            return "회원님은 워크스페이스 관리자입니다. 스페이스 관리자를 다른 멤버로 변경한 후 나갈 수 있습니다."
-        case .delete:
-           return "정말 이 스페이스를 삭제하시겠습니까? 삭제 시 채널/멤버/채팅 등 스페이스 내의 모든 정보가 삭제되며 복구할 수 없습니다."
-        case .edit, .changeOwner, .cancel:
-            return ""
-        }
+enum AlertText {
+    enum AlertButtonText: String {
+        case confirm = "확인"
+        case cancel = "취소"
     }
-}
-
-enum ChannelActionSheetText: String {
-    case add = "채널 추가"
-    case search = "채널 탐색"
-    case cancel = "취소"
+    
+    enum ChangeSpaceOwnerAlertText {
+        static let title = "워크스페이스 관리자 변경 불가"
+        static let description = "워크스페이스 멤버가 없어 관리자 변경을 할 수 없습니다. 새로운 멤버를 워크스페이스에 초대해보세요."
+    }
 }

--- a/Amor/Common/Constant/Design.swift
+++ b/Amor/Common/Constant/Design.swift
@@ -30,7 +30,7 @@ enum Design {
         static let hashtagLight = UIImage(named: "Hashtag_light")!
         static let hashtagBold = UIImage(named: "Hashtag_bold")!
         static let plus = UIImage(named: "PlusMark")!
-        static let xmark = UIImage(named: "Xmark")!
+        static let xmark = UIImage(named: "Xmark")?.withTintColor(.themeBlack, renderingMode: .alwaysOriginal)
         static let threeDots = UIImage(named: "ThreeDots")!
     }
     

--- a/Amor/Common/Constant/Navigation.swift
+++ b/Amor/Common/Constant/Navigation.swift
@@ -10,4 +10,5 @@ import Foundation
 enum Navigation {
     static let channelSetting = "채널 설정"
     static let editChannel = "채널 편집"
+    static let changeSpaceOwner = "스페이스 관리자 변경"
 }

--- a/Amor/Data/DTO/Space/ChangeSpaceOwnerRequestDTO.swift
+++ b/Amor/Data/DTO/Space/ChangeSpaceOwnerRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  ChangeSpaceOwnerRequestDTO.swift
+//  Amor
+//
+//  Created by 김상규 on 12/4/24.
+//
+
+import Foundation
+
+struct ChangeSpaceOwnerRequestDTO: Encodable {
+    let owner_id: String
+}

--- a/Amor/Data/DTO/Space/SpaceSimpleInfo.swift
+++ b/Amor/Data/DTO/Space/SpaceSimpleInfo.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct SpaceSimpleInfo: Decodable {
+struct SpaceSimpleInfo {
     let workspace_id: String
     let name: String
     let description: String?

--- a/Amor/Data/Repository/DefaultSpaceRepository.swift
+++ b/Amor/Data/Repository/DefaultSpaceRepository.swift
@@ -40,4 +40,8 @@ final class DefaultSpaceRepository: SpaceRepository {
     func fetchAddMember(request: SpaceRequestDTO, body: AddMemberRequestDTO) -> Single<Result<SpaceMemberResponseDTO, NetworkError>> {
         return networkManager.callNetwork(target: SpaceTarget.addMember(request: request, body: body), response: SpaceMemberResponseDTO.self)
     }
+    
+    func fetchChangeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO) -> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>> {
+        return networkManager.callNetwork(target: SpaceTarget.addMember(request: request, body: body), response: SpaceSimpleInfoResponseDTO.self)
+    }
 }

--- a/Amor/Data/Repository/DefaultSpaceRepository.swift
+++ b/Amor/Data/Repository/DefaultSpaceRepository.swift
@@ -41,7 +41,8 @@ final class DefaultSpaceRepository: SpaceRepository {
         return networkManager.callNetwork(target: SpaceTarget.addMember(request: request, body: body), response: SpaceMemberResponseDTO.self)
     }
     
-    func fetchChangeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO) -> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>> {
-        return networkManager.callNetwork(target: SpaceTarget.addMember(request: request, body: body), response: SpaceSimpleInfoResponseDTO.self)
+    func fetchChangeSpaceOwner(request: SpaceRequestDTO, body: ChangeSpaceOwnerRequestDTO) -> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>> {
+        print(request, body)
+        return networkManager.callNetwork(target: SpaceTarget.changeSpaceOwner(request: request, body: body), response: SpaceSimpleInfoResponseDTO.self)
     }
 }

--- a/Amor/Dependecny/Assembly.swift
+++ b/Amor/Dependecny/Assembly.swift
@@ -181,5 +181,17 @@ final class PresentAssembly: Assembly {
                 viewModel: resolver.resolve(ChannelSettingViewModel.self, argument: channelID)!
             )
         }
+        
+        container.register(ChangeSpaceOwnerViewModel.self) { resolver in
+            return ChangeSpaceOwnerViewModel(
+                useCase: resolver.resolve(SpaceUseCase.self)!
+            )
+        }
+        
+        container.register(ChangeSpaceOwnerViewController.self) { resolver in
+            return ChangeSpaceOwnerViewController(
+                viewModel: resolver.resolve(ChangeSpaceOwnerViewModel.self)!
+            )
+        }
     }
 }

--- a/Amor/Domain/Entity/Space/SpaceMember.swift
+++ b/Amor/Domain/Entity/Space/SpaceMember.swift
@@ -10,11 +10,13 @@ import Foundation
 struct SpaceMember {
     let user_id: String
     let nickname: String
+    let email: String
     let profileImage: String?
     
     init(_ dto: SpaceMemberResponseDTO) {
         self.user_id = dto.user_id
         self.nickname = dto.nickname
+        self.email = dto.email
         self.profileImage = dto.profileImage
     }
 }

--- a/Amor/Domain/Interface/SpaceRepository.swift
+++ b/Amor/Domain/Interface/SpaceRepository.swift
@@ -20,5 +20,5 @@ protocol SpaceRepository {
     -> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>>
     func fetchAddMember(request: SpaceRequestDTO, body: AddMemberRequestDTO)
     -> Single<Result<SpaceMemberResponseDTO, NetworkError>>
-    func fetchChangeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO)-> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>>
+    func fetchChangeSpaceOwner(request: SpaceRequestDTO, body: ChangeSpaceOwnerRequestDTO)-> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>>
 }

--- a/Amor/Domain/Interface/SpaceRepository.swift
+++ b/Amor/Domain/Interface/SpaceRepository.swift
@@ -20,4 +20,5 @@ protocol SpaceRepository {
     -> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>>
     func fetchAddMember(request: SpaceRequestDTO, body: AddMemberRequestDTO)
     -> Single<Result<SpaceMemberResponseDTO, NetworkError>>
+    func fetchChangeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO)-> Single<Result<SpaceSimpleInfoResponseDTO, NetworkError>>
 }

--- a/Amor/Domain/UseCase/SpaceUseCase.swift
+++ b/Amor/Domain/UseCase/SpaceUseCase.swift
@@ -21,7 +21,7 @@ protocol SpaceUseCase {
     -> Single<Result<SpaceSimpleInfo, NetworkError>>
     func addMember(request: SpaceRequestDTO, body: AddMemberRequestDTO)
     -> Single<Result<SpaceMember, NetworkError>>
-    func changeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO)
+    func changeSpaceOwner(request: SpaceRequestDTO, body: ChangeSpaceOwnerRequestDTO)
     -> Single<Result<SpaceSimpleInfo, NetworkError>>
 }
 
@@ -110,7 +110,7 @@ final class DefaultSpaceUseCase: SpaceUseCase {
             }
     }
     
-    func changeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO) -> Single<Result<SpaceSimpleInfo, NetworkError>> {
+    func changeSpaceOwner(request: SpaceRequestDTO, body: ChangeSpaceOwnerRequestDTO) -> Single<Result<SpaceSimpleInfo, NetworkError>> {
         spaceRepository.fetchChangeSpaceOwner(request: request, body: body)
             .flatMap{ result in
                 switch result {

--- a/Amor/Domain/UseCase/SpaceUseCase.swift
+++ b/Amor/Domain/UseCase/SpaceUseCase.swift
@@ -9,6 +9,8 @@ import Foundation
 import RxSwift
 
 protocol SpaceUseCase {
+    func getSpaceMembers(request: SpaceMembersRequestDTO)
+    -> Single<Result<[SpaceMember], NetworkError>>
     func getSpaceInfo(request: SpaceRequestDTO)
     -> Single<Result<SpaceInfo, NetworkError>>
     func getAllMySpaces()
@@ -19,6 +21,8 @@ protocol SpaceUseCase {
     -> Single<Result<SpaceSimpleInfo, NetworkError>>
     func addMember(request: SpaceRequestDTO, body: AddMemberRequestDTO)
     -> Single<Result<SpaceMember, NetworkError>>
+    func changeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO)
+    -> Single<Result<SpaceSimpleInfo, NetworkError>>
 }
 
 final class DefaultSpaceUseCase: SpaceUseCase {
@@ -26,6 +30,19 @@ final class DefaultSpaceUseCase: SpaceUseCase {
     
     init(spaceRepository: SpaceRepository) {
         self.spaceRepository = spaceRepository
+    }
+    
+    func getSpaceMembers(request: SpaceMembersRequestDTO) -> Single<Result<[SpaceMember], NetworkError>> {
+        spaceRepository.fetchSpaceMembers(request: request)
+            .flatMap { result in
+                switch result {
+                case .success(let success):
+                    return .just(.success(success.map { $0.toDomain() }))
+                case .failure(let error):
+                    print("getSpaceInfo error", error)
+                    return .just(.failure(error))
+                }
+            }
     }
   
     func getSpaceInfo(request: SpaceRequestDTO) 
@@ -83,6 +100,18 @@ final class DefaultSpaceUseCase: SpaceUseCase {
     
     func addMember(request: SpaceRequestDTO, body: AddMemberRequestDTO) -> Single<Result<SpaceMember, NetworkError>> {
         spaceRepository.fetchAddMember(request: request, body: body)
+            .flatMap{ result in
+                switch result {
+                case .success(let value):
+                    return .just(.success(value.toDomain()))
+                case .failure(let error):
+                    return .just(.failure(error))
+                }
+            }
+    }
+    
+    func changeSpaceOwner(request: SpaceRequestDTO, body: AddMemberRequestDTO) -> Single<Result<SpaceSimpleInfo, NetworkError>> {
+        spaceRepository.fetchChangeSpaceOwner(request: request, body: body)
             .flatMap{ result in
                 switch result {
                 case .success(let value):

--- a/Amor/Network/Target/SpaceTarget.swift
+++ b/Amor/Network/Target/SpaceTarget.swift
@@ -15,6 +15,7 @@ enum SpaceTarget {
     case createSpace(body: EditSpaceRequestDTO)
     case editSpace(request: SpaceRequestDTO, body: EditSpaceRequestDTO)
     case addMember(request: SpaceRequestDTO, body: AddMemberRequestDTO)
+    case changeSpaceOwner(request: SpaceRequestDTO, body: ChangeSpaceOwnerRequestDTO)
 }
 
 extension SpaceTarget: TargetType {
@@ -36,6 +37,8 @@ extension SpaceTarget: TargetType {
             return "workspaces/\(request.workspace_id)"
         case .addMember(let request, _):
             return "workspaces/\(request.workspace_id)/members"
+        case .changeSpaceOwner(let request, _):
+            return "workspaces/\(request.workspace_id)/transfer/ownership"
         }
     }
     
@@ -43,12 +46,12 @@ extension SpaceTarget: TargetType {
         switch self {
         case .getCurrentSpaceInfo, .getSpaceMember, .getAllMySpaces:
             return .get
-        case .editSpace:
-            return .put
         case .createSpace:
             return .post
         case .addMember:
             return .post
+        case .editSpace, .changeSpaceOwner:
+            return .put
         }
     }
     
@@ -117,6 +120,8 @@ extension SpaceTarget: TargetType {
             return .uploadMultipart(multipartData)
         case .addMember(_, let body):
             return .requestJSONEncodable(body)
+        case .changeSpaceOwner(_, let body):
+            return .requestJSONEncodable(body)
         }
     }
     
@@ -147,6 +152,12 @@ extension SpaceTarget: TargetType {
                 Header.authoriztion.rawValue: UserDefaultsStorage.token
             ]
         case .addMember:
+            return [
+                Header.contentType.rawValue: HeaderValue.json.rawValue,
+                Header.sesacKey.rawValue: apiKey,
+                Header.authoriztion.rawValue: UserDefaultsStorage.token
+            ]
+        case .changeSpaceOwner:
             return [
                 Header.contentType.rawValue: HeaderValue.json.rawValue,
                 Header.sesacKey.rawValue: apiKey,

--- a/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
+++ b/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
@@ -82,7 +82,7 @@ final class SideSpaceMenuCoordinator: Coordinator {
     }
     
     func presentChangeSpaceOwnerViewFlow() {
-        let vc = ChangeSpaceOwnerViewController(viewModel: ChangeSpaceOwnerViewModel(useCase: DefaultSpaceUseCase(spaceRepository: DefaultSpaceRepository(NetworkManager.shared))))
+        let vc: ChangeSpaceOwnerViewController = DIContainer.shared.resolve()
         vc.coordinator = self
         vc.delegate = self.sideSpaceMenuViewController
         customModalPresent(vc)

--- a/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
+++ b/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
@@ -12,6 +12,7 @@ final class SideSpaceMenuCoordinator: Coordinator {
     var childCoordinators = [Coordinator]()
     var navigationController: UINavigationController
     var sideSpaceMenuViewController: SideSpaceMenuViewController?
+    var modalNavigationController = UINavigationController()
     
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -24,6 +25,7 @@ final class SideSpaceMenuCoordinator: Coordinator {
         
         if let homeVC = self.navigationController.viewControllers.first as? HomeViewController {
             sideSpaceMenuViewController.delegate = homeVC
+            sideSpaceMenuViewController.coordinator = self
         }
 
         navigationController.tabBarController?.navigationController?.addChild(sideSpaceMenuViewController)
@@ -61,5 +63,32 @@ final class SideSpaceMenuCoordinator: Coordinator {
                 }
             }
         }
+    }
+    
+    func showAlertFlow(title: String, subtitle: String, alertType: CustomAlert.AlertType) {
+        let alertVC = CustomAlertController(title: title, subtitle: subtitle, alertType: alertType)
+        
+        navigationController.present(alertVC, animated: true)
+    }
+    
+    func presentSpaceActiveFlow(viewType: SpaceActiveViewType) {
+        let vc: SpaceActiveViewController = DIContainer.shared.resolve(arg: viewType)
+        vc.delegate = sideSpaceMenuViewController
+        customModalPresent(vc)
+    }
+    
+    func presentChangeSpaceOwnerViewFlow() {
+        customModalPresent(ChangeSpaceOwnerViewController())
+    }
+    
+    func customModalPresent(_ viewController: UIViewController) {
+        modalNavigationController = UINavigationController(
+            rootViewController: viewController
+        )
+        
+        if let sheet = modalNavigationController.sheetPresentationController {
+            sheet.prefersGrabberVisible = true
+        }
+        navigationController.present(modalNavigationController, animated: true)
     }
 }

--- a/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
+++ b/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
@@ -77,13 +77,14 @@ final class SideSpaceMenuCoordinator: Coordinator {
     
     func presentSpaceActiveFlow(viewType: SpaceActiveViewType) {
         let vc: SpaceActiveViewController = DIContainer.shared.resolve(arg: viewType)
-        vc.delegate = sideSpaceMenuViewController
+        vc.delegate = self.sideSpaceMenuViewController
         customModalPresent(vc)
     }
     
     func presentChangeSpaceOwnerViewFlow() {
         let vc = ChangeSpaceOwnerViewController(viewModel: ChangeSpaceOwnerViewModel(useCase: DefaultSpaceUseCase(spaceRepository: DefaultSpaceRepository(NetworkManager.shared))))
         vc.coordinator = self
+        vc.delegate = self.sideSpaceMenuViewController
         customModalPresent(vc)
     }
     

--- a/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
+++ b/Amor/Presentation/Coordinator/SideSpaceMenuCoordinator.swift
@@ -65,10 +65,14 @@ final class SideSpaceMenuCoordinator: Coordinator {
         }
     }
     
-    func showAlertFlow(title: String, subtitle: String, alertType: CustomAlert.AlertType) {
-        let alertVC = CustomAlertController(title: title, subtitle: subtitle, alertType: alertType)
+    func showAlertFlow(title: String, subtitle: String, alertType: CustomAlert.AlertType, completionHandler: (()->Void)? = nil) {
+        let alertVC = CustomAlertController(title: title, subtitle: subtitle, alertType: alertType, completionHandler: completionHandler)
         
-        navigationController.present(alertVC, animated: true)
+        navigationController.visibleViewController?.present(alertVC, animated: true)
+    }
+    
+    func dismissAlertFlow() {
+        navigationController.dismiss(animated: true)
     }
     
     func presentSpaceActiveFlow(viewType: SpaceActiveViewType) {
@@ -78,7 +82,9 @@ final class SideSpaceMenuCoordinator: Coordinator {
     }
     
     func presentChangeSpaceOwnerViewFlow() {
-        customModalPresent(ChangeSpaceOwnerViewController())
+        let vc = ChangeSpaceOwnerViewController(viewModel: ChangeSpaceOwnerViewModel(useCase: DefaultSpaceUseCase(spaceRepository: DefaultSpaceRepository(NetworkManager.shared))))
+        vc.coordinator = self
+        customModalPresent(vc)
     }
     
     func customModalPresent(_ viewController: UIViewController) {

--- a/Amor/Presentation/CustomView/CustomAlert.swift
+++ b/Amor/Presentation/CustomView/CustomAlert.swift
@@ -19,8 +19,8 @@ final class CustomAlert: BaseView {
     let containerView = UIView()
     let titleLabel = UILabel()
     let subtitleLabel = UILabel()
-    lazy var confirmButton = CommonButton(title: AlertButtonText.confirm.rawValue, foregroundColor: .themeWhite, backgroundColor: .themeGreen)
-    var cancelButton = CommonButton(title: AlertButtonText.cancel.rawValue, foregroundColor: .themeWhite, backgroundColor: .themeInactive)
+    lazy var confirmButton = CommonButton(title: AlertText.AlertButtonText.confirm.rawValue, foregroundColor: .themeWhite, backgroundColor: .themeGreen)
+    var cancelButton = CommonButton(title: AlertText.AlertButtonText.cancel.rawValue, foregroundColor: .themeWhite, backgroundColor: .themeInactive)
     
     let alertType: AlertType
     

--- a/Amor/Presentation/CustomView/CustomAlertController.swift
+++ b/Amor/Presentation/CustomView/CustomAlertController.swift
@@ -11,7 +11,10 @@ import RxCocoa
 
 final class CustomAlertController: BaseVC<CustomAlert> {
     
-    init(title: String, subtitle: String, alertType: CustomAlert.AlertType) {
+    var completionHandler: (() -> Void)?
+    
+    init(title: String, subtitle: String, alertType: CustomAlert.AlertType, completionHandler: (() -> Void)? = nil) {
+        self.completionHandler = completionHandler
         super.init(baseView: CustomAlert(alertType: alertType))
         
         baseView.configureView(title: title, subtitle: subtitle)
@@ -29,7 +32,7 @@ final class CustomAlertController: BaseVC<CustomAlert> {
         
         baseView.confirmButtonTap()
             .bind(with: self) { owner, _ in
-                self.dismiss(animated: true)
+                owner.completionHandler?()
             }
             .disposed(by: disposeBag)
     }

--- a/Amor/Presentation/CustomView/SpaceNavigationBarView.swift
+++ b/Amor/Presentation/CustomView/SpaceNavigationBarView.swift
@@ -62,7 +62,7 @@ final class SpaceNavigationBarView: UIView {
         if let imageURL = image, let url = URL(string: apiUrl + imageURL) {
             spaceImageView.kf.setImage(with: url)
         } else {
-            spaceImageView.backgroundColor = .themeBlack
+            spaceImageView.image = .workspace
         }
     }
     

--- a/Amor/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/Amor/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -21,8 +21,7 @@ final class AddChannelViewController: BaseVC<AddChannelView> {
     
     override func configureNavigationBar() {
         self.navigationItem.title = "채널 생성"
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "Xmark"), style: .plain, target: self, action: nil)
-        self.navigationItem.leftBarButtonItem?.tintColor = .themeBlack
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: Design.Icon.xmark, style: .plain, target: self, action: nil)
     }
     
     override func bind() {

--- a/Amor/Presentation/Home/ViewController/AddMemberViewController.swift
+++ b/Amor/Presentation/Home/ViewController/AddMemberViewController.swift
@@ -20,13 +20,18 @@ final class AddMemberViewController: BaseVC<AddMemberView> {
     
     override func configureNavigationBar() {
         self.navigationItem.title = "팀원 초대"
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "Xmark"), style: .plain, target: self, action: nil)
-        self.navigationItem.leftBarButtonItem?.tintColor = .themeBlack
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: Design.Icon.xmark, style: .plain, target: self, action: nil)
     }
     
     override func bind() {
         let input = AddMemberViewModel.Input(emailText: baseView.emailTextFieldText(), addButtonClicked: baseView.addMemberButtonClicked())
         let output = viewModel.transform(input)
+        
+        navigationItem.leftBarButtonItem?.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.dismiss(animated: true)
+            }
+            .disposed(by: disposeBag)
         
         output.addButtonEnabled
             .bind(with: self) { owner, value in

--- a/Amor/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Amor/Presentation/Home/ViewController/HomeViewController.swift
@@ -182,16 +182,16 @@ extension HomeViewController {
     func showActionSheet() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-        actionSheet.addAction(UIAlertAction(title: ChannelActionSheetText.add.rawValue, style: .default, handler: { [weak self] _ in
+        actionSheet.addAction(UIAlertAction(title: ActionSheetText.ChannelActionSheetText.add.rawValue, style: .default, handler: { [weak self] _ in
             self?.coordinator?.showAddChannelFlow()
         }))
         
-        actionSheet.addAction(UIAlertAction(title: ChannelActionSheetText.search.rawValue, style: .default, handler: { [weak self] _ in
+        actionSheet.addAction(UIAlertAction(title: ActionSheetText.ChannelActionSheetText.search.rawValue, style: .default, handler: { [weak self] _ in
             let nav = UINavigationController(rootViewController: UIViewController())
             self?.present(nav, animated: true)
         }))
         
-        actionSheet.addAction(UIAlertAction(title: ChannelActionSheetText.cancel.rawValue, style: .cancel, handler: nil))
+        actionSheet.addAction(UIAlertAction(title: ActionSheetText.ChannelActionSheetText.cancel.rawValue, style: .cancel, handler: nil))
         
         self.present(actionSheet, animated: true, completion: nil)
     }

--- a/Amor/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Amor/Presentation/Home/ViewController/HomeViewController.swift
@@ -213,8 +213,9 @@ extension HomeViewController: AddMemberDelegate {
 extension HomeViewController: SideSpaceMenuDelegate {
     
     func updateSpace(spaceSimpleInfo: SpaceSimpleInfo) {
-        baseView.navBar.configureNavTitle(.home(spaceSimpleInfo.name))
-        baseView.navBar.configureSpaceImageView(image: spaceSimpleInfo.coverImage)
+        fetchHome.onNext(spaceSimpleInfo.workspace_id)
+//        baseView.navBar.configureNavTitle(.home(spaceSimpleInfo.name))
+//        baseView.navBar.configureSpaceImageView(image: spaceSimpleInfo.coverImage)
     }
     
     func updateHome(spaceID: String) {

--- a/Amor/Presentation/Space/View/Cell/ChangeSpaceOwnerView.swift
+++ b/Amor/Presentation/Space/View/Cell/ChangeSpaceOwnerView.swift
@@ -1,0 +1,8 @@
+//
+//  ChangeSpaceOwnerView.swift
+//  Amor
+//
+//  Created by 김상규 on 12/4/24.
+//
+
+import Foundation

--- a/Amor/Presentation/Space/View/Cell/SpaceCollectionViewCell.swift
+++ b/Amor/Presentation/Space/View/Cell/SpaceCollectionViewCell.swift
@@ -12,8 +12,8 @@ import RxSwift
 import RxCocoa
 
 final class SpaceCollectionViewCell: BaseCollectionViewCell {
-    let spaceImageView = UIImageView()
-    let spaceTitleLabel = {
+    let imageView = UIImageView()
+    let titleLabel = {
         let label = UILabel()
         label.font = .bodyBold
         label.textColor = .textPrimary
@@ -21,7 +21,7 @@ final class SpaceCollectionViewCell: BaseCollectionViewCell {
         return label
     }()
 
-    let createdDateLabel = {
+    let subTitleLabel = {
         let label = UILabel()
         label.font = .body
         label.textColor = .textSecondary
@@ -36,9 +36,9 @@ final class SpaceCollectionViewCell: BaseCollectionViewCell {
     }()
     
     override func configureHierarchy() {
-        contentView.addSubview(spaceImageView)
-        contentView.addSubview(spaceTitleLabel)
-        contentView.addSubview(createdDateLabel)
+        contentView.addSubview(imageView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(subTitleLabel)
         contentView.addSubview(moreButton)
     }
     
@@ -47,45 +47,61 @@ final class SpaceCollectionViewCell: BaseCollectionViewCell {
             make.edges.equalTo(safeAreaLayoutGuide).inset(5)
         }
         
-        spaceImageView.snp.makeConstraints { make in
+        imageView.snp.makeConstraints { make in
             make.size.equalTo(44)
             make.verticalEdges.leading.equalTo(safeAreaLayoutGuide).inset(16)
         }
         
         moreButton.snp.makeConstraints { make in
-            make.size.equalTo(30)
-            make.centerY.equalTo(spaceImageView)
+            make.size.equalTo(0)
+            make.centerY.equalTo(imageView)
             make.trailing.equalTo(safeAreaLayoutGuide).inset(10)
         }
         
-        spaceTitleLabel.snp.makeConstraints { make in
-            make.leading.equalTo(spaceImageView.snp.trailing).offset(5)
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(imageView.snp.trailing).offset(5)
             make.trailing.equalTo(moreButton.snp.leading).inset(-5)
-            make.bottom.equalTo(spaceImageView.snp.centerY)
+            make.bottom.equalTo(imageView.snp.centerY)
             make.height.equalTo(18)
         }
         
-        createdDateLabel.snp.makeConstraints { make in
-            make.leading.equalTo(spaceTitleLabel)
+        subTitleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(titleLabel)
             make.trailing.equalTo(moreButton.snp.leading).inset(-5)
-            make.top.equalTo(spaceImageView.snp.centerY)
+            make.top.equalTo(imageView.snp.centerY)
             make.height.equalTo(18)
-            make.width.equalTo(spaceTitleLabel)
+            make.width.equalTo(titleLabel)
         }
     }
     
-    func configureCell(spaceSimpleInfo: SpaceSimpleInfo) {
+    func configureCell<T>(item: T) {
         contentView.layer.cornerRadius = 8
         contentView.clipsToBounds = true
         
-        if let image = spaceSimpleInfo.coverImage, let url = URL(string: apiUrl + image) {
-            spaceImageView.kf.setImage(with: url)
-        } else {
-            spaceImageView.backgroundColor = .systemGreen
+        switch item {
+        case let spaceSimpleInfo as SpaceSimpleInfo:
+            if let image = spaceSimpleInfo.coverImage, let url = URL(string: apiUrl + image) {
+                imageView.kf.setImage(with: url)
+            } else {
+                imageView.backgroundColor = .systemGreen
+            }
+            titleLabel.text = spaceSimpleInfo.name
+            subTitleLabel.text = spaceSimpleInfo.createdAt.toSpaceCreatedDate()
+            setMoreButtonLayout(isHidden: false)
+            configureisCurrentSpaceCell(isCurrentSpace: spaceSimpleInfo.isCurrentSpace)
+        case let spaceMember as SpaceMember:
+            if let image = spaceMember.profileImage, let url = URL(string: apiUrl + image) {
+                imageView.kf.setImage(with: url)
+            } else {
+                imageView.image = .userBot
+            }
+            
+            setMoreButtonLayout(isHidden: true)
+            titleLabel.text = spaceMember.nickname
+            subTitleLabel.text = spaceMember.email
+        default:
+            setMoreButtonLayout(isHidden: true)
         }
-        spaceTitleLabel.text = spaceSimpleInfo.name
-        createdDateLabel.text = spaceSimpleInfo.createdAt.toSpaceCreatedDate()
-        configureisCurrentSpaceCell(isCurrentSpace: spaceSimpleInfo.isCurrentSpace)
     }
     
     func configureisCurrentSpaceCell(isCurrentSpace: Bool) {
@@ -97,11 +113,21 @@ final class SpaceCollectionViewCell: BaseCollectionViewCell {
         return moreButton.rx.tap
     }
     
+    private func setMoreButtonLayout(isHidden: Bool) {
+        moreButton.isHidden = isHidden
+        
+        if !isHidden {
+            moreButton.snp.updateConstraints { make in
+                make.size.equalTo(30)
+            }
+        }
+    }
+    
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        spaceImageView.layer.cornerRadius = 8
-        spaceImageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true
     }
     
     override func prepareForReuse() {

--- a/Amor/Presentation/Space/View/ChangeSpaceOwnerView.swift
+++ b/Amor/Presentation/Space/View/ChangeSpaceOwnerView.swift
@@ -1,0 +1,28 @@
+//
+//  ChangeSpaceOwnerView.swift
+//  Amor
+//
+//  Created by 김상규 on 12/4/24.
+//
+
+import UIKit
+import SnapKit
+
+final class ChangeSpaceOwnerView: BaseView {
+    lazy var spaceMemberCollectionView = {
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: setSideSpaceMenuCollectionViewLayout())
+        cv.register(SpaceCollectionViewCell.self, forCellWithReuseIdentifier: SpaceCollectionViewCell.identifier)
+        
+        return cv
+    }()
+    
+    override func configureHierarchy() {
+        addSubview(spaceMemberCollectionView)
+    }
+    
+    override func configureLayout() {
+        spaceMemberCollectionView.snp.makeConstraints { make in
+            make.edges.equalTo(safeAreaLayoutGuide)
+        }
+    }
+}

--- a/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerView.swift
+++ b/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerView.swift
@@ -1,0 +1,8 @@
+//
+//  ChangeSpaceOwnerView.swift
+//  Amor
+//
+//  Created by 김상규 on 12/4/24.
+//
+
+import Foundation

--- a/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
+++ b/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
@@ -1,0 +1,26 @@
+//
+//  ChangeSpaceOwnerViewController.swift
+//  Amor
+//
+//  Created by 김상규 on 12/4/24.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class ChangeSpaceOwnerViewController: BaseVC<ChangeSpaceOwnerView> {
+    
+    override func configureNavigationBar() {
+        navigationItem.title = Navigation.changeSpaceOwner
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: Design.Icon.xmark, style: .plain, target: self, action: nil)
+    }
+    
+    override func bind() {
+        navigationItem.leftBarButtonItem?.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.dismiss(animated: true)
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
+++ b/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
@@ -25,12 +25,13 @@ final class ChangeSpaceOwnerViewController: BaseVC<ChangeSpaceOwnerView> {
     }
     
     override func bind() {
-        let input = ChangeSpaceOwnerViewModel.Input(trigger: BehaviorRelay<Void>(value: ()))
+        let changedSpaceOwner = PublishSubject<SpaceMember>()
+        let input = ChangeSpaceOwnerViewModel.Input(trigger: BehaviorRelay<Void>(value: ()), changedSpaceOwner: changedSpaceOwner)
         let output = viewModel.transform(input)
         
         output.disabledChangeSpaceOwner
             .bind(with: self) { owner, _ in
-                owner.coordinator?.showAlertFlow(title: AlertText.ChangeSpaceOwnerAlertText.title, subtitle: AlertText.ChangeSpaceOwnerAlertText.description, alertType: .oneButton) {
+                owner.coordinator?.showAlertFlow(title: AlertText.ChangeSpaceOwnerAlertText.changeDisabled.title, subtitle: AlertText.ChangeSpaceOwnerAlertText.changeDisabled.description, alertType: .oneButton) {
                     owner.coordinator?.dismissAlertFlow()
                 }
             }
@@ -41,7 +42,14 @@ final class ChangeSpaceOwnerViewController: BaseVC<ChangeSpaceOwnerView> {
                 cell.configureCell(item: item)
             }
             .disposed(by: disposeBag)
-            
+        
+        baseView.spaceMemberCollectionView.rx.modelSelected(SpaceMember.self)
+            .bind(with: self) { owner, value in
+                owner.coordinator?.showAlertFlow(title: AlertText.ChangeSpaceOwnerAlertText.changeEnalbled(value.nickname).title, subtitle: AlertText.ChangeSpaceOwnerAlertText.changeEnalbled(value.nickname).description, alertType: .twoButton) {
+                    changedSpaceOwner.onNext(value)
+                }
+            }
+            .disposed(by: disposeBag)
         
         navigationItem.leftBarButtonItem?.rx.tap
             .bind(with: self) { owner, _ in

--- a/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
+++ b/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
@@ -10,6 +10,14 @@ import RxSwift
 import RxCocoa
 
 final class ChangeSpaceOwnerViewController: BaseVC<ChangeSpaceOwnerView> {
+    var coordinator: SideSpaceMenuCoordinator?
+    let viewModel: ChangeSpaceOwnerViewModel
+    
+    init(viewModel: ChangeSpaceOwnerViewModel) {
+        self.viewModel = viewModel
+        
+        super.init()
+    }
     
     override func configureNavigationBar() {
         navigationItem.title = Navigation.changeSpaceOwner
@@ -17,6 +25,24 @@ final class ChangeSpaceOwnerViewController: BaseVC<ChangeSpaceOwnerView> {
     }
     
     override func bind() {
+        let input = ChangeSpaceOwnerViewModel.Input(trigger: BehaviorRelay<Void>(value: ()))
+        let output = viewModel.transform(input)
+        
+        output.disabledChangeSpaceOwner
+            .bind(with: self) { owner, _ in
+                owner.coordinator?.showAlertFlow(title: AlertText.ChangeSpaceOwnerAlertText.title, subtitle: AlertText.ChangeSpaceOwnerAlertText.description, alertType: .oneButton) {
+                    owner.coordinator?.dismissAlertFlow()
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        output.spaceMember
+            .bind(to: baseView.spaceMemberCollectionView.rx.items(cellIdentifier: SpaceCollectionViewCell.identifier, cellType: SpaceCollectionViewCell.self)) { (index, item, cell) in
+                cell.configureCell(item: item)
+            }
+            .disposed(by: disposeBag)
+            
+        
         navigationItem.leftBarButtonItem?.rx.tap
             .bind(with: self) { owner, _ in
                 owner.dismiss(animated: true)

--- a/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
+++ b/Amor/Presentation/Space/ViewController/ChangeSpaceOwnerViewController.swift
@@ -12,6 +12,7 @@ import RxCocoa
 final class ChangeSpaceOwnerViewController: BaseVC<ChangeSpaceOwnerView> {
     var coordinator: SideSpaceMenuCoordinator?
     let viewModel: ChangeSpaceOwnerViewModel
+    var delegate: ChangeSpaceOwnerDelegate?
     
     init(viewModel: ChangeSpaceOwnerViewModel) {
         self.viewModel = viewModel
@@ -51,10 +52,19 @@ final class ChangeSpaceOwnerViewController: BaseVC<ChangeSpaceOwnerView> {
             }
             .disposed(by: disposeBag)
         
+        output.changeOwnerComplete
+            .bind(with: self) { owner, value in
+                owner.delegate?.changeOwnerCompleteAction(spaceSimpleInfo: value)
+            }
+            .disposed(by: disposeBag)
+        
         navigationItem.leftBarButtonItem?.rx.tap
             .bind(with: self) { owner, _ in
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
     }
+}
+protocol ChangeSpaceOwnerDelegate: AnyObject {
+    func changeOwnerCompleteAction(spaceSimpleInfo: SpaceSimpleInfo)
 }

--- a/Amor/Presentation/Space/ViewController/SideSpaceMenuViewController.swift
+++ b/Amor/Presentation/Space/ViewController/SideSpaceMenuViewController.swift
@@ -15,6 +15,7 @@ protocol SideSpaceMenuDelegate: AnyObject {
 }
 
 final class SideSpaceMenuViewController: BaseVC<SideSpaceMenuView> {
+    var coordinator: SideSpaceMenuCoordinator?
     private let space = PublishRelay<SpaceSimpleInfo?>()
     private let viewModel: SideSpaceMenuViewModel
     var delegate: SideSpaceMenuDelegate?
@@ -66,7 +67,7 @@ final class SideSpaceMenuViewController: BaseVC<SideSpaceMenuView> {
         
         baseView.addWorkSpaceButton.rx.tap
             .bind(with: self) { owner, _ in
-                owner.presentSpaceActiveFlow(viewType: .create(nil))
+                owner.coordinator?.presentSpaceActiveFlow(viewType: .create(nil))
             }
             .disposed(by: disposeBag)
     }
@@ -78,22 +79,22 @@ extension SideSpaceMenuViewController {
         
         let leaveAction = UIAlertAction(title: SpaceActionSheetText.leave.rawValue, style: .default, handler: { [weak self] _ in
             if UserDefaultsStorage.userId == spaceSimpleInfo.owner_id {
-                self?.showAlert(title: SpaceActionSheetText.leave.rawValue, subtitle: SpaceActionSheetText.leave.alertDescription, alertType: .oneButton)
+                self?.coordinator?.showAlertFlow(title: SpaceActionSheetText.leave.rawValue, subtitle: SpaceActionSheetText.leave.alertDescription, alertType: .oneButton)
             } else {
                 print("스페이스 나가기 실행")
             }
         })
         
         let editAction = UIAlertAction(title: SpaceActionSheetText.edit.rawValue, style: .default, handler: { [weak self] _ in
-            self?.presentSpaceActiveFlow(viewType: .edit(spaceSimpleInfo))
+            self?.coordinator?.presentSpaceActiveFlow(viewType: .edit(spaceSimpleInfo))
         })
         
         let changeOwnerAction = UIAlertAction(title: SpaceActionSheetText.changeOwner.rawValue, style: .default, handler: { [weak self] _ in
-            print("스페이스 관리자 변경")
+            self?.coordinator?.presentChangeSpaceOwnerViewFlow()
         })
         
         let deleteAction = UIAlertAction(title: SpaceActionSheetText.delete.rawValue, style: .destructive, handler: { [weak self] _ in
-            self?.showAlert(title: SpaceActionSheetText.delete.rawValue, subtitle: SpaceActionSheetText.delete.alertDescription, alertType: .twoButton)
+            self?.coordinator?.showAlertFlow(title: SpaceActionSheetText.delete.rawValue, subtitle: SpaceActionSheetText.delete.alertDescription, alertType: .twoButton)
         })
         
         if spaceSimpleInfo.owner_id == UserDefaultsStorage.userId {
@@ -108,21 +109,6 @@ extension SideSpaceMenuViewController {
         actionSheet.addAction(UIAlertAction(title: SpaceActionSheetText.cancel.rawValue, style: .cancel))
         
         self.present(actionSheet, animated: true, completion: nil)
-    }
-}
-
-extension SideSpaceMenuViewController {
-    func showAlert(title: String, subtitle: String, alertType: CustomAlert.AlertType) {
-        let alertVC = CustomAlertController(title: title, subtitle: subtitle, alertType: alertType)
-        
-        present(alertVC, animated: true)
-    }
-    
-    func presentSpaceActiveFlow(viewType: SpaceActiveViewType) {
-        let vc: SpaceActiveViewController = DIContainer.shared.resolve(arg: viewType)
-        vc.delegate = self
-        let nav = UINavigationController(rootViewController: vc)
-        self.present(nav, animated: true)
     }
 }
 

--- a/Amor/Presentation/Space/ViewController/SideSpaceMenuViewController.swift
+++ b/Amor/Presentation/Space/ViewController/SideSpaceMenuViewController.swift
@@ -33,7 +33,7 @@ final class SideSpaceMenuViewController: BaseVC<SideSpaceMenuView> {
         
         output.mySpaces
             .bind(to: baseView.spaceCollectionView.rx.items(cellIdentifier: SpaceCollectionViewCell.identifier, cellType: SpaceCollectionViewCell.self)) { (index, item, cell) in
-                cell.configureCell(spaceSimpleInfo: item)
+                cell.configureCell(item: item)
                 
                 cell.tapMoreButton()
                     .map { item }
@@ -77,24 +77,24 @@ extension SideSpaceMenuViewController {
     private func showSpaceActionSheet(spaceSimpleInfo: SpaceSimpleInfo) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-        let leaveAction = UIAlertAction(title: SpaceActionSheetText.leave.rawValue, style: .default, handler: { [weak self] _ in
+        let leaveAction = UIAlertAction(title: ActionSheetText.SpaceActionSheetText.leave.rawValue, style: .default, handler: { [weak self] _ in
             if UserDefaultsStorage.userId == spaceSimpleInfo.owner_id {
-                self?.coordinator?.showAlertFlow(title: SpaceActionSheetText.leave.rawValue, subtitle: SpaceActionSheetText.leave.alertDescription, alertType: .oneButton)
+                self?.coordinator?.showAlertFlow(title: ActionSheetText.SpaceActionSheetText.leave.rawValue, subtitle: ActionSheetText.SpaceActionSheetText.leave.alertDescription, alertType: .oneButton)
             } else {
                 print("스페이스 나가기 실행")
             }
         })
         
-        let editAction = UIAlertAction(title: SpaceActionSheetText.edit.rawValue, style: .default, handler: { [weak self] _ in
+        let editAction = UIAlertAction(title: ActionSheetText.SpaceActionSheetText.edit.rawValue, style: .default, handler: { [weak self] _ in
             self?.coordinator?.presentSpaceActiveFlow(viewType: .edit(spaceSimpleInfo))
         })
         
-        let changeOwnerAction = UIAlertAction(title: SpaceActionSheetText.changeOwner.rawValue, style: .default, handler: { [weak self] _ in
+        let changeOwnerAction = UIAlertAction(title: ActionSheetText.SpaceActionSheetText.changeOwner.rawValue, style: .default, handler: { [weak self] _ in
             self?.coordinator?.presentChangeSpaceOwnerViewFlow()
         })
         
-        let deleteAction = UIAlertAction(title: SpaceActionSheetText.delete.rawValue, style: .destructive, handler: { [weak self] _ in
-            self?.coordinator?.showAlertFlow(title: SpaceActionSheetText.delete.rawValue, subtitle: SpaceActionSheetText.delete.alertDescription, alertType: .twoButton)
+        let deleteAction = UIAlertAction(title: ActionSheetText.SpaceActionSheetText.delete.rawValue, style: .destructive, handler: { [weak self] _ in
+            self?.coordinator?.showAlertFlow(title: ActionSheetText.SpaceActionSheetText.delete.rawValue, subtitle: ActionSheetText.SpaceActionSheetText.delete.alertDescription, alertType: .twoButton)
         })
         
         if spaceSimpleInfo.owner_id == UserDefaultsStorage.userId {
@@ -106,7 +106,7 @@ extension SideSpaceMenuViewController {
             actionSheet.addAction(leaveAction)
         }
         
-        actionSheet.addAction(UIAlertAction(title: SpaceActionSheetText.cancel.rawValue, style: .cancel))
+        actionSheet.addAction(UIAlertAction(title: ActionSheetText.SpaceActionSheetText.cancel.rawValue, style: .cancel))
         
         self.present(actionSheet, animated: true, completion: nil)
     }

--- a/Amor/Presentation/Space/ViewController/SideSpaceMenuViewController.swift
+++ b/Amor/Presentation/Space/ViewController/SideSpaceMenuViewController.swift
@@ -20,6 +20,8 @@ final class SideSpaceMenuViewController: BaseVC<SideSpaceMenuView> {
     private let viewModel: SideSpaceMenuViewModel
     var delegate: SideSpaceMenuDelegate?
     
+    let trigger = BehaviorSubject<Void>(value: ())
+    
     init(viewModel: SideSpaceMenuViewModel) {
         self.viewModel = viewModel
         
@@ -27,7 +29,6 @@ final class SideSpaceMenuViewController: BaseVC<SideSpaceMenuView> {
     }
     
     override func bind() {
-        let trigger = BehaviorSubject<Void>(value: ())
         let input = SideSpaceMenuViewModel.Input(trigger: trigger, space: space)
         let output = viewModel.transform(input)
         
@@ -118,5 +119,13 @@ extension SideSpaceMenuViewController: SpaceActiveViewDelegate {
         if spaceSimpleInfo.isCurrentSpace {
             delegate?.updateSpace(spaceSimpleInfo: spaceSimpleInfo)
         }
+    }
+}
+
+extension SideSpaceMenuViewController: ChangeSpaceOwnerDelegate {
+    func changeOwnerCompleteAction(spaceSimpleInfo: SpaceSimpleInfo) {
+        actionComplete(spaceSimpleInfo: spaceSimpleInfo)
+        trigger.onNext(())
+        coordinator?.dismissAlertFlow()
     }
 }

--- a/Amor/Presentation/Space/ViewModel/ChangeSpaceOwnerViewModel.swift
+++ b/Amor/Presentation/Space/ViewModel/ChangeSpaceOwnerViewModel.swift
@@ -25,11 +25,13 @@ final class ChangeSpaceOwnerViewModel: BaseViewModel {
     struct Output {
         let disabledChangeSpaceOwner: PublishSubject<Void>
         let spaceMember: BehaviorSubject<[SpaceMember]>
+        let changeOwnerComplete: PublishSubject<SpaceSimpleInfo>
     }
     
     func transform(_ input: Input) -> Output {
         let disabledChangeSpaceOwner = PublishSubject<Void>()
         let spaceMember = BehaviorSubject<[SpaceMember]>(value: [])
+        let changeOwnerComplete = PublishSubject<SpaceSimpleInfo>()
         
         input.trigger
             .map { SpaceMembersRequestDTO(workspace_id: UserDefaultsStorage.spaceId) }
@@ -55,7 +57,7 @@ final class ChangeSpaceOwnerViewModel: BaseViewModel {
             .bind(with: self) { owner, result in
                 switch result {
                 case .success(let success):
-                    print(success)
+                    changeOwnerComplete.onNext(success)
                 case .failure(let error):
                     print(error)
                 }
@@ -63,6 +65,6 @@ final class ChangeSpaceOwnerViewModel: BaseViewModel {
             .disposed(by: disposeBag)
             
         
-        return Output(disabledChangeSpaceOwner: disabledChangeSpaceOwner, spaceMember: spaceMember)
+        return Output(disabledChangeSpaceOwner: disabledChangeSpaceOwner, spaceMember: spaceMember, changeOwnerComplete: changeOwnerComplete)
     }
 }

--- a/Amor/Presentation/Space/ViewModel/ChangeSpaceOwnerViewModel.swift
+++ b/Amor/Presentation/Space/ViewModel/ChangeSpaceOwnerViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  ChangeSpaceOwnerViewModel.swift
+//  Amor
+//
+//  Created by 김상규 on 12/4/24.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class ChangeSpaceOwnerViewModel: BaseViewModel {
+    let disposeBag = DisposeBag()
+    let useCase: SpaceUseCase
+    
+    init(useCase: SpaceUseCase) {
+        self.useCase = useCase
+    }
+    
+    struct Input {
+        let trigger: BehaviorRelay<Void>
+    }
+    
+    struct Output {
+        let disabledChangeSpaceOwner: PublishSubject<Void>
+        let spaceMember: BehaviorSubject<[SpaceMember]>
+    }
+    
+    func transform(_ input: Input) -> Output {
+        let disabledChangeSpaceOwner = PublishSubject<Void>()
+        let spaceMember = BehaviorSubject<[SpaceMember]>(value: [])
+        
+        input.trigger
+            .map { SpaceMembersRequestDTO(workspace_id: UserDefaultsStorage.spaceId) }
+            .flatMap { self.useCase.getSpaceMembers(request: $0)}
+            .bind(with: self) { owner, result in
+                switch result {
+                case .success(let success):
+                    if success.count == 1 {
+                        disabledChangeSpaceOwner.onNext(())
+                    } else {
+                        spaceMember.onNext(success)
+                    }
+                case .failure(let error):
+                    print(error)
+                }
+            }
+            .disposed(by: disposeBag)
+            
+        
+        return Output(disabledChangeSpaceOwner: disabledChangeSpaceOwner, spaceMember: spaceMember)
+    }
+}

--- a/Amor/Presentation/User/View/LoginView.swift
+++ b/Amor/Presentation/User/View/LoginView.swift
@@ -48,7 +48,7 @@ final class LoginView: BaseView {
     
     override func configureView() {
         backgroundColor = .backgroundPrimary
-        emailTextField.textField.text = "qwe123@gmail.com"
+        emailTextField.textField.text = ""
         passwordTextField.textField.text = "Qwer1234!"
     }
 }

--- a/Amor/Presentation/User/ViewController/EditProfileViewController.swift
+++ b/Amor/Presentation/User/ViewController/EditProfileViewController.swift
@@ -32,7 +32,6 @@ final class EditProfileViewController: BaseVC<EditProfileView> {
     
     override func configureNavigationBar() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "Chevron_left"), style: .plain, target: self, action: nil)
-        navigationItem.leftBarButtonItem?.tintColor = .label
     }
     
     func bind(element: ProfileElement) {

--- a/Amor/Presentation/User/ViewController/MyProfileViewController.swift
+++ b/Amor/Presentation/User/ViewController/MyProfileViewController.swift
@@ -30,7 +30,6 @@ final class MyProfileViewController: BaseVC<MyProfileView> {
     override func configureNavigationBar() {
         navigationItem.title = "내 정보 수정"
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "Chevron_left"), style: .plain, target: self, action: nil)
-        navigationItem.leftBarButtonItem?.tintColor = .label
     }
     
     override func bind() {

--- a/Amor/Presentation/User/ViewController/OtherProfileViewController.swift
+++ b/Amor/Presentation/User/ViewController/OtherProfileViewController.swift
@@ -12,7 +12,6 @@ final class OtherProfileViewController: BaseVC<OtherProfileView> {
     override func configureNavigationBar() {
         navigationItem.title = "프로필"
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "Chevron_left"), style: .plain, target: self, action: nil)
-        navigationItem.leftBarButtonItem?.tintColor = .label
     }
     
     override func bind() {


### PR DESCRIPTION
## 🚀관련 이슈
- #46 

## ✨작업 내용
- 스페이스 관리자 변경 기능 구현
  - 스페이스에 현재 유저만 존재하는 경우 관리자 변경 불가능 알럿 표시 후 뷰 dismiss 진행
  - 현재 관리자를 제외한 멤버 뷰를 표시한 후 멤버 클릭 시 관리자 변경 알럿 표시
  - 확인 버튼 클릭 시 관리자 변경과 함께 SideSpaceMenu 뷰의 스페이스 목록 업데이트 & 홈뷰 업데이트 진행

## 📝참고 사항
- CustomAlert의 confirm 버튼 동작을 위한 completionHandler 추가
